### PR TITLE
feat: Testing infrastructure + improved pandas read

### DIFF
--- a/src/buckley24drought/sgi.py
+++ b/src/buckley24drought/sgi.py
@@ -1,7 +1,7 @@
 """SGI module"""
 # pylint: disable=R0801
 from functools import partial
-from importlib.resources import files, as_file
+from importlib.resources import files
 
 import numpy as np
 import pandas as pd
@@ -249,15 +249,14 @@ class SGI:
             )
 
         # get well data from package resources
-        rsrc = files(swl).joinpath(f"{gwicid}.csv")
-        with as_file(rsrc) as csv:
-            self.data = pd.read_csv(
-                csv,
-                index_col="date",
-                usecols=["gwicid", "date", "daily_average"],
-                # enforce date type for date column
-                parse_dates=[1],
-            )
+        rsrc = files(swl) / f"{gwicid}.csv"
+        self.data = pd.read_csv(
+            rsrc,
+            index_col="date",
+            usecols=["gwicid", "date", "daily_average"],
+            # enforce date type for date column
+            parse_dates=["date"],
+        )
         # interpret water levels as heads
         self.data["daily_average"] = -self.data["daily_average"]
 

--- a/src/buckley24drought/spei.py
+++ b/src/buckley24drought/spei.py
@@ -1,7 +1,7 @@
 """SPEI module"""
 # pylint: disable=R0801
 from functools import partial
-from importlib.resources import files, as_file
+from importlib.resources import files
 
 import numpy as np
 import pandas as pd
@@ -60,15 +60,14 @@ class SPEI:
 
     def __init__(self):
         # get climatic water balance data from package resources
-        rsrc = files(gridmet).joinpath("balance_eto_gridmet_1981_2020.csv")
-        with as_file(rsrc) as csv:
-            self.data = pd.read_csv(
-                csv,
-                # start_date not needed for analysis
-                usecols=["area", "end_date", "value"],
-                # enforce date type for end_date column
-                parse_dates=[1],
-            )
+        rsrc = files(gridmet) / "balance_eto_gridmet_1981_2020.csv"
+        self.data = pd.read_csv(
+            rsrc,
+            # start_date not needed for analysis
+            usecols=["area", "end_date", "value"],
+            # enforce date type for end_date column
+            parse_dates=["end_date"],
+        )
         # add integer column for the month number
         self.data["month"] = self.data["end_date"].apply(lambda x: x.month)
 

--- a/src/buckley24drought/spi.py
+++ b/src/buckley24drought/spi.py
@@ -1,7 +1,7 @@
 """SPI module"""
 # pylint: disable=R0801
 from functools import partial
-from importlib.resources import files, as_file
+from importlib.resources import files
 
 import numpy as np
 import pandas as pd
@@ -22,15 +22,14 @@ class SPI:
 
     def __init__(self):
         # get precipitation data from package resources
-        rsrc = files(gridmet).joinpath("precip_gridmet_1981_2020.csv")
-        with as_file(rsrc) as csv:
-            self.data = pd.read_csv(
-                csv,
-                # start_date not needed for analysis
-                usecols=["area", "end_date", "value"],
-                # enforce date type for end_date column
-                parse_dates=[1],
-            )
+        rsrc = files(gridmet) / "precip_gridmet_1981_2020.csv"
+        self.data = pd.read_csv(
+            rsrc,
+            # start_date not needed for analysis
+            usecols=["area", "end_date", "value"],
+            # enforce date type for end_date column
+            parse_dates=["end_date"],
+        )
         # add integer column for the month number
         self.data["month"] = self.data["end_date"].apply(lambda x: x.month)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import pytest
+
+SUITES = ("slow", "intg")
+
+def pytest_addoption(parser):
+    """
+    A pytest hook function that allows us to add additional command line arguments
+    and manage which tests are run.
+    """
+    for suite in SUITES:
+        parser.addoption(
+            f"--{suite}",
+            action="store_true",
+            default=False,
+            help=f"run {suite} tests",
+        )
+
+    parser.addoption(
+        "--all",
+        action="store_true",
+        default=False,
+        help="run all tests",
+    )
+
+def pytest_configure(config):
+    """
+    Mark tests with the suite name.
+    """
+    for suite in SUITES:
+        config.addinivalue_line(
+            "markers", f"{suite}: mark test as {suite}"
+        )
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Skip tests that are not explicitly under the given suite.
+    """
+    skips = {suite: pytest.mark.skip(reason=f"--{suite} not set") for suite in SUITES}
+    run = set(name for name in SUITES if config.getoption(f"--{name}"))
+
+    if config.getoption("--all"):
+        run = set(SUITES)
+
+    for item in items:
+        if not set(item.keywords) & run:
+            for suitename in set(SUITES) & set(item.keywords):
+                item.add_marker(skips[suitename])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
+from typing import List
+
 import pytest
 
 SUITES = ("slow", "intg")
 
-def pytest_addoption(parser):
-    """
-    A pytest hook function that allows us to add additional command line arguments
-    and manage which tests are run.
+
+def pytest_addoption(parser: pytest.Parser):
+    """A pytest hook function that allows us to add additional
+    command line arguments and manage which tests are run.
+
+    Parameters
+    ----------
+    parser : pytest.Parser
     """
     for suite in SUITES:
         parser.addoption(
@@ -22,18 +28,25 @@ def pytest_addoption(parser):
         help="run all tests",
     )
 
-def pytest_configure(config):
-    """
-    Mark tests with the suite name.
+
+def pytest_configure(config: pytest.Config):
+    """Mark tests with the suite name.
+
+    Parameters
+    ----------
+    config : pytest.Config
     """
     for suite in SUITES:
-        config.addinivalue_line(
-            "markers", f"{suite}: mark test as {suite}"
-        )
+        config.addinivalue_line("markers", f"{suite}: mark test as {suite}")
 
-def pytest_collection_modifyitems(config, items):
-    """
-    Skip tests that are not explicitly under the given suite.
+
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
+    """Skip tests that are not explicitly under the given suite.
+
+    Parameters
+    ----------
+    config : pytest.Config
+    items : list of pytest.Item
     """
     skips = {suite: pytest.mark.skip(reason=f"--{suite} not set") for suite in SUITES}
     run = set(name for name in SUITES if config.getoption(f"--{name}"))

--- a/tests/test_sgi.py
+++ b/tests/test_sgi.py
@@ -73,6 +73,7 @@ def test_SGI_create(gwicid):
     assert sgi.data.dtypes["monthly_average"].kind == "f"
 
 
+@pytest.mark.intg
 def test_SGI_generate_series():
     sgi = SGI(gwicid=32)
     res = sgi.generate_series()
@@ -87,6 +88,7 @@ def test_SGI_generate_series():
     assert res.dtypes["SGI"].kind == "f"
 
 
+@pytest.mark.intg
 def test_SGI_check_fit():
     sgi = SGI(gwicid=32)
     fit = sgi.check_fit()


### PR DESCRIPTION
Features:
- Added functionality to mark tests as "slow"/"integration". I've been given advice in the past that good tests should run in under a second. However, as we all know, sometimes we need to test on something real (connecting to a DB, or cloud storage, or start a cluster). These should still have tests, but not necessarily be run every time to improve development iteration times. It looks like there were two tests within SGI that were taking nearly 2.5 mins each to run. I marked them as slow, so I could make sure my stuff for reading the DataFrames didn't ruin any of your tests. (You can still run everything using the --all or --intg option in the command line).
- I simplified your `read_csv` function. Pandas is extremely flexible and can take the `Transversable` path type as-is without issue. From my understanding, Pandas manages the opening/closing of files, so you don't need the `with open()` line.

Random suggestions:
There were a couple of things I wanted to make mention of that might help with maintainability and usability.

1. I've been told it's bad practice to do heavy lifting (such as reading DataFrames) within the `init()` of a class. This makes it harder to break apart the class into its components and mock them. You could consider passing along a path to a DataFrame, and then reading it in a `fit` function.
2. I suggest that the column names/dataframe path be configurable to the classes. It'd drastically improve the reusability of the library to other datasets that someone may have. (It'd also help others know what should be in the DataFrames). That'd also decrease your reliance on keeping a copy of the data within the repo (which is usually frowned upon, especially with larger datasets due to how Git tracks them.)
3. The `index_data` folder could easily become part of the overall library: It'd allow others to pull data to use the library with a known, working dataset (again, avoiding having to keep `.csv`'s in your repo).